### PR TITLE
Update linked-list.test.js

### DIFF
--- a/_tests_/linked-list.test.js
+++ b/_tests_/linked-list.test.js
@@ -77,7 +77,7 @@ describe("Linked Lists", () => {
   });
 
   test("Convert data from linked lists into an array", () => {
-    expect(numList.toArray()).toEqual([0, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    expect(numList.toArray()).toEqual([0, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
   });
 
   test("Check for duplicates", () => {


### PR DESCRIPTION
Hi Karolin! I'm pretty sure 10 should not be in the expected array for the .toArray method. 10 gets deleted from numList prior to the .toArray method tests when the .delete method test runs. My understanding is that since .beforeAll is being used to construct numList, the numList that gets modified by .delete is the same instance being tested for the .toArray method. 