### PR TITLE
Updated test to equal the correct array

### DIFF
--- a/_tests_/linked-list.test.js
+++ b/_tests_/linked-list.test.js
@@ -77,7 +77,7 @@ describe("Linked Lists", () => {
   });
 
   test("Convert data from linked lists into an array", () => {
-    expect(numList.toArray()).toEqual([0, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    expect(numList.toArray()).toEqual([0, 10, 9, 8, 7, 6, 5, 4, 3, 2]);
   });
 
   test("Check for duplicates", () => {


### PR DESCRIPTION
Convert data from linked lists into array should be <[0, 10, 9, 8, 7, 6, 5, 4, 3, 2> instead of <[0, 9, 8, 7, 6, 5, 4, 3, 2, 1>